### PR TITLE
[BUG] Fix pad-conv fusion bug when pad has multiple consumers

### DIFF
--- a/docs/_static/style.css
+++ b/docs/_static/style.css
@@ -1,3 +1,3 @@
 .wy-nav-content {
-    max-width: 1100px !important;
+  max-width: 1100px !important;
 }

--- a/onnxslim/argparser.py
+++ b/onnxslim/argparser.py
@@ -1,8 +1,9 @@
-import onnxslim
 import argparse
 import dataclasses
 from dataclasses import dataclass, field
 from typing import List, Optional, Type
+
+import onnxslim
 
 
 @dataclass
@@ -13,6 +14,7 @@ class ModelArguments:
 
         output_model (str, optional): File path to save the slimmed model. If None, the model will not be saved.
     """
+
     input_model: str = field(metadata={"help": "input onnx model"})
     output_model: Optional[str] = field(default=None, metadata={"help": "output onnx model"})
 
@@ -27,9 +29,18 @@ class OptimizationArguments:
 
         skip_fusion_patterns (str, optional): String representing fusion patterns to skip. Default is None.
     """
+
     no_shape_infer: bool = field(default=False, metadata={"help": "whether to disable shape_infer, default false."})
-    no_constant_folding: bool = field(default=False, metadata={"help": "whether to disable constant_folding, default false."})
-    skip_fusion_patterns: Optional[List[str]] = field(default=None, metadata={"help": "whether to skip the fusion of some patterns", "choices": list(onnxslim.DEFAULT_FUSION_PATTERNS.keys())})
+    no_constant_folding: bool = field(
+        default=False, metadata={"help": "whether to disable constant_folding, default false."}
+    )
+    skip_fusion_patterns: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "whether to skip the fusion of some patterns",
+            "choices": list(onnxslim.DEFAULT_FUSION_PATTERNS.keys()),
+        },
+    )
 
 
 @dataclass
@@ -44,11 +55,31 @@ class ModificationArguments:
 
         save_as_external_data (bool, optional): Flag indicating whether to split onnx as model and weight. Default is False.
     """
-    input_shapes: Optional[List[str]] = field(default=None, metadata={"help": "input shape of the model, INPUT_NAME:SHAPE, e.g. x:1,3,224,224 or x1:1,3,224,224 x2:1,3,224,224"})
-    inputs: Optional[List[str]] = field(default=None, metadata={"help": "input of the model, INPUT_NAME:DTYPE, e.g. y:fp32 or y1:fp32 y2:fp32. If dtype is not specified, the dtype of the input will be the same as the original model if it has dtype, otherwise it will be fp32, available dtype: fp16, fp32, int32"})
-    outputs: Optional[List[str]] = field(default=None, metadata={"help": "output of the model, OUTPUT_NAME:DTYPE, e.g. y:fp32 or y1:fp32 y2:fp32. If dtype is not specified, the dtype of the output will be the same as the original model if it has dtype, otherwise it will be fp32, available dtype: fp16, fp32, int32"})
-    dtype: Optional[str] = field(default=None, metadata={"help": "convert data format to fp16 or fp32.", "choices": ["fp16", "fp32"]})
-    save_as_external_data: bool = field(default=False, metadata={"help": "split onnx as model and weight, default False."})
+
+    input_shapes: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "input shape of the model, INPUT_NAME:SHAPE, e.g. x:1,3,224,224 or x1:1,3,224,224 x2:1,3,224,224"
+        },
+    )
+    inputs: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "input of the model, INPUT_NAME:DTYPE, e.g. y:fp32 or y1:fp32 y2:fp32. If dtype is not specified, the dtype of the input will be the same as the original model if it has dtype, otherwise it will be fp32, available dtype: fp16, fp32, int32"
+        },
+    )
+    outputs: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "output of the model, OUTPUT_NAME:DTYPE, e.g. y:fp32 or y1:fp32 y2:fp32. If dtype is not specified, the dtype of the output will be the same as the original model if it has dtype, otherwise it will be fp32, available dtype: fp16, fp32, int32"
+        },
+    )
+    dtype: Optional[str] = field(
+        default=None, metadata={"help": "convert data format to fp16 or fp32.", "choices": ["fp16", "fp32"]}
+    )
+    save_as_external_data: bool = field(
+        default=False, metadata={"help": "split onnx as model and weight, default False."}
+    )
 
 
 @dataclass
@@ -65,8 +96,14 @@ class CheckerArguments:
 
         verbose (bool, optional): Flag indicating whether to print verbose logs. Default is False.
     """
+
     model_check: bool = field(default=False, metadata={"help": "enable model check"})
-    model_check_inputs: Optional[List[str]] = field(default=None, metadata={"help": "Works only when model_check is enabled, Input shape of the model or numpy data path, INPUT_NAME:SHAPE or INPUT_NAME:DATAPATH, e.g. x:1,3,224,224 or x1:1,3,224,224 x2:data.npy. Useful when input shapes are dynamic."})
+    model_check_inputs: Optional[List[str]] = field(
+        default=None,
+        metadata={
+            "help": "Works only when model_check is enabled, Input shape of the model or numpy data path, INPUT_NAME:SHAPE or INPUT_NAME:DATAPATH, e.g. x:1,3,224,224 or x1:1,3,224,224 x2:data.npy. Useful when input shapes are dynamic."
+        },
+    )
     inspect: bool = field(default=False, metadata={"help": "inspect model, default False."})
     dump_to_disk: bool = field(default=False, metadata={"help": "dump model info to disk, default False."})
     verbose: bool = field(default=False, metadata={"help": "verbose mode, default False."})

--- a/onnxslim/cli/_main.py
+++ b/onnxslim/cli/_main.py
@@ -2,12 +2,11 @@ from typing import Union
 
 import onnx
 
-def slim(model: Union[str, onnx.ModelProto], *args, **kwargs):
 
+def slim(model: Union[str, onnx.ModelProto], *args, **kwargs):
     import os
     import time
     from pathlib import Path
-
 
     from onnxslim.core import (
         convert_data_format,
@@ -29,19 +28,19 @@ def slim(model: Union[str, onnx.ModelProto], *args, **kwargs):
         summarize_model,
     )
 
-    output_model = args[0] if len(args) > 0 else kwargs.get('output_model', None)
-    model_check = kwargs.get('model_check', False)
-    input_shapes = kwargs.get('input_shapes', None)
-    outputs = kwargs.get('outputs', None)
-    no_shape_infer = kwargs.get('no_shape_infer', False)
-    no_constant_folding = kwargs.get('no_constant_folding', False)
-    dtype = kwargs.get('dtype', None)
-    skip_fusion_patterns = kwargs.get('skip_fusion_patterns', None)
-    inspect = kwargs.get('inspect', False)
-    dump_to_disk = kwargs.get('dump_to_disk', False)
-    save_as_external_data = kwargs.get('save_as_external_data', False)
-    model_check_inputs = kwargs.get('model_check_inputs', None)
-    verbose = kwargs.get('verbose', False)
+    output_model = args[0] if len(args) > 0 else kwargs.get("output_model", None)
+    model_check = kwargs.get("model_check", False)
+    input_shapes = kwargs.get("input_shapes", None)
+    outputs = kwargs.get("outputs", None)
+    no_shape_infer = kwargs.get("no_shape_infer", False)
+    no_constant_folding = kwargs.get("no_constant_folding", False)
+    dtype = kwargs.get("dtype", None)
+    skip_fusion_patterns = kwargs.get("skip_fusion_patterns", None)
+    inspect = kwargs.get("inspect", False)
+    dump_to_disk = kwargs.get("dump_to_disk", False)
+    save_as_external_data = kwargs.get("save_as_external_data", False)
+    model_check_inputs = kwargs.get("model_check_inputs", None)
+    verbose = kwargs.get("verbose", False)
 
     logger = init_logging(verbose)
 
@@ -119,7 +118,13 @@ def slim(model: Union[str, onnx.ModelProto], *args, **kwargs):
 
 def main():
     """Entry point for the OnnxSlim toolkit, processes command-line arguments and passes them to the slim function."""
-    from onnxslim.argparser import ArgumentParser, ModelArguments, OptimizationArguments, ModificationArguments, CheckerArguments
+    from onnxslim.argparser import (
+        ArgumentParser,
+        CheckerArguments,
+        ModelArguments,
+        ModificationArguments,
+        OptimizationArguments,
+    )
 
     argument_parser = ArgumentParser(ModelArguments, OptimizationArguments, ModificationArguments, CheckerArguments)
     model_args, optimization_args, modification_args, checker_args = argument_parser.parse_args_into_dataclasses()
@@ -135,9 +140,12 @@ def main():
 
         check_onnx_compatibility()
 
-    slim(model_args.input_model, model_args.output_model,
-         **optimization_args.__dict__,
-         **modification_args.__dict__,
-         **checker_args.__dict__)
+    slim(
+        model_args.input_model,
+        model_args.output_model,
+        **optimization_args.__dict__,
+        **modification_args.__dict__,
+        **checker_args.__dict__,
+    )
 
     return 0

--- a/onnxslim/core/__init__.py
+++ b/onnxslim/core/__init__.py
@@ -1,5 +1,5 @@
-import os
 import logging
+import os
 import tempfile
 
 import numpy as np
@@ -12,7 +12,8 @@ from onnxslim.core.utils import delete_node
 from onnxslim.third_party.onnx_graphsurgeon.ir.tensor import Constant
 from onnxslim.third_party.symbolic_shape_infer import SymbolicShapeInference
 from onnxslim.utils import save
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 
 
 DEBUG = bool(os.getenv("ONNXSLIM_DEBUG"))

--- a/onnxslim/core/optimization/__init__.py
+++ b/onnxslim/core/optimization/__init__.py
@@ -8,7 +8,8 @@ import onnxslim.third_party.onnx_graphsurgeon as gs
 from onnxslim.core.pattern import get_node_feeds
 from onnxslim.core.pattern.registry import get_fusion_patterns
 from onnxslim.third_party.onnx_graphsurgeon.ir.graph import Graph
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 
 from .dead_node_elimination import dead_node_elimination
 from .subexpression_elimination import subexpression_elimination

--- a/onnxslim/core/optimization/dead_node_elimination.py
+++ b/onnxslim/core/optimization/dead_node_elimination.py
@@ -1,11 +1,13 @@
 import logging
+
 import numpy as np
 
 import onnxslim.third_party.onnx_graphsurgeon as gs
 from onnxslim.core.utils import delete_node
 from onnxslim.third_party.onnx_graphsurgeon.exporters.onnx_exporter import dtype_to_onnx
 from onnxslim.third_party.onnx_graphsurgeon.ir.tensor import Constant, Variable
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 
 
 def dead_node_elimination(graph):

--- a/onnxslim/core/optimization/subexpression_elimination.py
+++ b/onnxslim/core/optimization/subexpression_elimination.py
@@ -1,7 +1,9 @@
 import logging
+
 from onnxslim.core.pattern import get_node_users
 from onnxslim.third_party.onnx_graphsurgeon.ir.tensor import Variable
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 
 
 def find_and_remove_replaceable_nodes(nodes):

--- a/onnxslim/core/optimization/weight_tying.py
+++ b/onnxslim/core/optimization/weight_tying.py
@@ -1,11 +1,11 @@
 import logging
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 import onnxslim.third_party.onnx_graphsurgeon as gs
 
 
 def tie_weights(graph):
     """Tie weights in a computational graph to reduce the number of parameters."""
-
     tensor_map = graph.tensors()
     constant_tensors = [tensor for tensor in tensor_map.values() if isinstance(tensor, gs.Constant)]
 

--- a/onnxslim/core/pattern/__init__.py
+++ b/onnxslim/core/pattern/__init__.py
@@ -1,10 +1,11 @@
-import re
 import logging
+import re
 from abc import abstractmethod
 
 import onnxslim.third_party.onnx_graphsurgeon as gs
 from onnxslim.third_party.onnx_graphsurgeon import Constant
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 
 
 def get_node_users(node):

--- a/onnxslim/core/pattern/elimination/unsqueeze.py
+++ b/onnxslim/core/pattern/elimination/unsqueeze.py
@@ -61,8 +61,12 @@ class UnsqueezePatternMatcher(PatternMatcher):
                     attrs = {"axes": axes_node_unsqueeze_0 + axes_node_unsqueeze_1}
                 else:
                     attrs = None
-                    inputs.append(gs.Constant(name=f"{node_unsqueeze_0.name}_axes",
-                                  values=np.array(axes_node_unsqueeze_0 + axes_node_unsqueeze_1, dtype=np.int64)))
+                    inputs.append(
+                        gs.Constant(
+                            name=f"{node_unsqueeze_0.name}_axes",
+                            values=np.array(axes_node_unsqueeze_0 + axes_node_unsqueeze_1, dtype=np.int64),
+                        )
+                    )
 
                 match_case[node_unsqueeze_0.name] = {
                     "op": "Unsqueeze",

--- a/onnxslim/core/pattern/fusion/gelu.py
+++ b/onnxslim/core/pattern/fusion/gelu.py
@@ -1,5 +1,4 @@
-from onnxslim.core.pattern import Pattern, PatternMatcher, get_node_users
-from onnxslim.core.pattern.registry import register_fusion_pattern
+from onnxslim.core.pattern import Pattern, PatternMatcher
 
 
 class GeluPatternMatcher(PatternMatcher):

--- a/onnxslim/core/pattern/fusion/padconv.py
+++ b/onnxslim/core/pattern/fusion/padconv.py
@@ -33,9 +33,9 @@ class PadConvMatcher(PatternMatcher):
         node = self.conv_0
         pad_node = self.pad_0
         input_variable = self.pad_0.inputs[0]
+        pad_node_users = get_node_users(pad_node)
 
         pad_value = pad_node.inputs[1].values.tolist()
-        input_variable.outputs.remove(pad_node)
 
         pad_variable = pad_node.outputs[0]  # pad output variable
         index = node.inputs.index(pad_variable)
@@ -48,8 +48,12 @@ class PadConvMatcher(PatternMatcher):
 
         node.inputs.clear()
         node.outputs.clear()
-        pad_node.inputs.clear()
-        pad_node.outputs.clear()
+        # remove pad node if it has only one user
+        if len(pad_node_users) == 1:
+            input_variable.outputs.remove(pad_node)
+            pad_node.inputs.clear()
+            pad_node.outputs.clear()
+
         conv_pads = attrs["pads"]
         len_conv_pads = len(conv_pads) // 2
 

--- a/onnxslim/misc/tabulate.py
+++ b/onnxslim/misc/tabulate.py
@@ -776,7 +776,7 @@ _float_with_thousands_separators = re.compile(r"^(([+-]?[0-9]{1,3})(?:,([0-9]{3}
 
 
 def simple_separated_format(separator):
-    """
+    r"""
     Construct a simple TableFormat with columns separated by a separator.
 
     >>> tsv = simple_separated_format("\\t") ; \
@@ -818,7 +818,7 @@ def _isnumber_with_thousands_separator(string):
     >>> _isnumber_with_thousands_separator("+1,000.1234")
     True
     >>> _isnumber_with_thousands_separator("-1,000.1234")
-    True
+    True.
     """
     try:
         string = string.decode()
@@ -848,7 +848,7 @@ def _isnumber(string):
     >>> _isnumber("123e45678")
     False
     >>> _isnumber("inf")
-    True
+    True.
     """
     if not _isconvertible(float, string):
         return False
@@ -862,7 +862,7 @@ def _isint(string, inttype=int):
     >>> _isint("123")
     True
     >>> _isint("123.45")
-    False
+    False.
     """
     return (
         type(string) is inttype
@@ -881,13 +881,13 @@ def _isbool(string):
     >>> _isbool("False")
     True
     >>> _isbool(1)
-    False
+    False.
     """
     return type(string) is bool or (isinstance(string, (bytes, str)) and string in {"True", "False"})
 
 
 def _type(string, has_invisible=True, numparse=True):
-    """
+    r"""
     The least generic type (type(None), int, float, str, unicode).
 
     >>> _type(None) is type(None)
@@ -901,7 +901,6 @@ def _type(string, has_invisible=True, numparse=True):
     >>> _type('\x1b[31m42\x1b[0m') is type(42)
     True
     """
-
     if has_invisible and isinstance(string, (str, bytes)):
         string = _strip_ansi(string)
 
@@ -1004,7 +1003,7 @@ def _strip_ansi(s):
 
 
 def _visible_width(s):
-    """
+    r"""
     Visible width of a printed string. ANSI color codes are removed.
 
     >>> _visible_width('\x1b[31mhello\x1b[0m'), _visible_width("world")
@@ -1108,7 +1107,7 @@ def _align_column(
     enable_widechars=False,
     is_multiline=False,
 ):
-    """[string] -> [padded_string]"""
+    """[string] -> [padded_string]."""
     strings, padfn = _align_column_choose_padfn(strings, alignment, has_invisible)
     width_fn = _align_column_choose_width_fn(has_invisible, enable_widechars, is_multiline)
 
@@ -1324,7 +1323,6 @@ def _normalize_tabular_data(tabular_data, headers, showindex="default"):
     If showindex="never", don't show row indices for all types of data.
     If showindex is an iterable, show its values as row indices.
     """
-
     try:
         bool(headers)
         is_headers2bool_broken = False  # noqa
@@ -1532,7 +1530,7 @@ def tabulate(
     rowalign=None,
     maxheadercolwidths=None,
 ):
-    """
+    r"""
     Format a fixed width table for pretty printing.
 
     >>> print(tabulate([[1, 2.34], [-56, "8.999"], ["2", "10001"]]))
@@ -2025,7 +2023,6 @@ def tabulate(
 
     Header column width can be specified in a similar way using `maxheadercolwidth`
     """
-
     if tabular_data is None:
         tabular_data = []
 
@@ -2565,7 +2562,7 @@ class _CustomTextWrap(textwrap.TextWrapper):
 
 def _main():
     """\
-    Usage: tabulate [options] [FILE ...]
+    Usage: tabulate [options] [FILE ...].
 
     Pretty-print tabular data.
     See also https://github.com/astanin/python-tabulate

--- a/onnxslim/third_party/onnx_graphsurgeon/exporters/onnx_exporter.py
+++ b/onnxslim/third_party/onnx_graphsurgeon/exporters/onnx_exporter.py
@@ -45,7 +45,6 @@ def dtype_to_onnx(dtype: Union[np.dtype, "onnx.TensorProto.DataType"]) -> int:
 
 def check_duplicate_node_names(nodes: Sequence[Node], level=G_LOGGER.WARNING):
     """Check if node names are unique and log any duplicates based on the specified severity level."""
-
     # Note:
     # Empty string or None attribute values are not considered duplicates.
     name_map = {}

--- a/onnxslim/third_party/onnx_graphsurgeon/ir/function.py
+++ b/onnxslim/third_party/onnx_graphsurgeon/ir/function.py
@@ -212,7 +212,6 @@ class Function(Graph):
         Returns:
             Function: A copy of the function.
         """
-
         local_tensor_copies = {n: t.copy() for n, t in self.tensors().items()}
 
         def get_tensor(name):

--- a/onnxslim/third_party/onnx_graphsurgeon/ir/graph.py
+++ b/onnxslim/third_party/onnx_graphsurgeon/ir/graph.py
@@ -392,6 +392,7 @@ class Graph(object):
             recurse_functions (bool):
                     Whether to also clean up this graph's local functions.
                     Defaults to True.
+
         Returns:
             self
         """
@@ -498,7 +499,6 @@ class Graph(object):
         Returns:
             self
         """
-
         ALLOWED_MODES = ["full", "nodes", "functions"]
         if mode not in ALLOWED_MODES:
             G_LOGGER.critical(f'Mode "{mode}" not in {ALLOWED_MODES}')
@@ -543,7 +543,6 @@ class Graph(object):
 
         def get_hierarchy_level(node_or_func, visited=None):
             """Returns the hierarchy level of a node or function, with optional tracking of visited elements."""
-
             visited = misc.default_value(visited, set())
             visited.add(get_id(node_or_func))
 

--- a/onnxslim/third_party/onnx_graphsurgeon/ir/tensor.py
+++ b/onnxslim/third_party/onnx_graphsurgeon/ir/tensor.py
@@ -29,7 +29,7 @@ class Tensor(object):
     DYNAMIC = -1
 
     def __init__(self):
-        """**This class is abstract and cannot be constructed directly.**"""
+        """**This class is abstract and cannot be constructed directly.**."""
         raise NotImplementedError("Tensor is an abstract class")
 
     def __setattr__(self, name, value):
@@ -79,6 +79,7 @@ class Tensor(object):
                     Generally, this will come from onnx.TensorProto.DataLocation.
 
             dtype (Union[numpy.dtype, onnx.TensorProto.DataType]): The data type of the tensor.
+
         Returns:
             self
         """
@@ -103,7 +104,6 @@ class Tensor(object):
         Returns:
             self
         """
-
         if shape is None:
             shape = []
         variable_dtype = dtype if dtype is not None else self.export_dtype

--- a/onnxslim/third_party/symbolic_shape_infer.py
+++ b/onnxslim/third_party/symbolic_shape_infer.py
@@ -1954,7 +1954,7 @@ class SymbolicShapeInference:
                 return all(d >= 0 for d in flatten_min(y - x))
 
         def handle_negative_index(index, bound):
-            """Normalizes a negative index to be in [0, bound)"""
+            """Normalizes a negative index to be in [0, bound)."""
             try:
                 if not less_equal(0, index):
                     if is_literal(index) and index <= -self.int_max_:

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -12,7 +12,8 @@ import onnxslim.third_party.onnx_graphsurgeon as gs
 from onnxslim.misc.font import GREEN, WHITE
 from onnxslim.misc.tabulate import SEPARATING_LINE, tabulate
 from onnxslim.third_party.onnx_graphsurgeon.logger.logger import G_LOGGER
-logger = logging.getLogger('onnxslim')
+
+logger = logging.getLogger("onnxslim")
 
 
 def init_logging(verbose=False):
@@ -28,7 +29,7 @@ def init_logging(verbose=False):
 
     if not logger.handlers:
         handler = logging.StreamHandler(sys.stderr)
-        formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+        formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
         handler.setFormatter(formatter)
         logger.addHandler(handler)
 
@@ -424,8 +425,13 @@ def is_converged(model: onnx.ModelProto, graph_ckpt, iter: int) -> bool:
         return False
 
 
-def save(model: onnx.ModelProto, model_path: str, model_check: bool = False,
-         save_as_external_data: bool = False, model_info: Dict = None):
+def save(
+    model: onnx.ModelProto,
+    model_path: str,
+    model_check: bool = False,
+    save_as_external_data: bool = False,
+    model_info: Dict = None,
+):
     """Save an ONNX model to a specified path, with optional model checking for validity."""
     if model_check:
         try:

--- a/tests/test_modelzoo.py
+++ b/tests/test_modelzoo.py
@@ -1,33 +1,33 @@
 import os
-
-import pytest
 import tempfile
+
 import numpy as np
 import onnxruntime as ort
+import pytest
 
 from onnxslim import slim
 from onnxslim.utils import print_model_info_as_table, summarize_model
 
 MODELZOO_PATH = "/data/modelzoo"
 
+
 class TestModelZoo:
     def test_silero_vad(self, request):
-        name = request.node.originalname[len("test_"):]
+        name = request.node.originalname[len("test_") :]
         filename = f"{MODELZOO_PATH}/{name}/{name}.onnx"
 
         with tempfile.TemporaryDirectory() as tempdir:
-            slim(filename, os.path.join(tempdir, f"{name}_slim.onnx")) 
+            slim(filename, os.path.join(tempdir, f"{name}_slim.onnx"))
             batch_size = 2
             input = np.zeros((batch_size, 256), dtype=np.float32)
             sr = np.array(16000)
             state = np.zeros((2, batch_size, 128), dtype=np.float32)
 
             ort_sess = ort.InferenceSession(os.path.join(tempdir, f"{name}_slim.onnx"))
-            outputs = ort_sess.run(None, {'input': input, 'sr': sr, 'state': state})
-
+            ort_sess.run(None, {"input": input, "sr": sr, "state": state})
 
     def test_decoder_with_past_model(self, request):
-        name = request.node.originalname[len("test_"):]
+        name = request.node.originalname[len("test_") :]
         filename = f"{MODELZOO_PATH}/{name}/{name}.onnx"
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -37,28 +37,25 @@ class TestModelZoo:
             encoder_hidden_states = np.zeros((batch_size, 128, 16), dtype=np.float32)
 
             ort_sess = ort.InferenceSession(os.path.join(tempdir, f"{name}_slim.onnx"))
-            outputs = ort_sess.run(None, {'input_ids': input_ids, 'encoder_hidden_states': encoder_hidden_states})
-
+            ort_sess.run(None, {"input_ids": input_ids, "encoder_hidden_states": encoder_hidden_states})
 
     def test_tiny_en_decoder(self, request):
-        name = request.node.originalname[len("test_"):]
+        name = request.node.originalname[len("test_") :]
         filename = f"{MODELZOO_PATH}/{name}/{name}.onnx"
 
         with tempfile.TemporaryDirectory() as tempdir:
             slim(filename, os.path.join(tempdir, f"{name}_slim.onnx"), model_check=True)
 
-
     def test_transformer_encoder(self, request):
-        name = request.node.originalname[len("test_"):]
+        name = request.node.originalname[len("test_") :]
         filename = f"{MODELZOO_PATH}/{name}/{name}.onnx"
         summary = summarize_model(slim(filename))
         print_model_info_as_table(request.node.name, summary)
         assert summary["op_type_counts"]["Mul"] == 57
         assert summary["op_type_counts"]["Div"] == 53
 
-
     def test_uiex(self, request):
-        name = request.node.originalname[len("test_"):]
+        name = request.node.originalname[len("test_") :]
         filename = f"{MODELZOO_PATH}/{name}/{name}.onnx"
         summary = summarize_model(slim(filename))
         print_model_info_as_table(request.node.name, summary)

--- a/tests/test_onnxslim.py
+++ b/tests/test_onnxslim.py
@@ -1,11 +1,11 @@
 import os
-import pytest
-import tempfile
 import subprocess
+import tempfile
+
+import pytest
 
 from onnxslim import slim
 from onnxslim.utils import print_model_info_as_table, summarize_model
-
 
 MODELZOO_PATH = "/data/modelzoo"
 FILENAME = f"{MODELZOO_PATH}/resnet18/resnet18.onnx"
@@ -41,7 +41,7 @@ class TestFeature:
         import numpy as np
 
         with tempfile.TemporaryDirectory() as tempdir:
-            output_name = os.path.join(tempdir, f"resnet18.onnx")
+            output_name = os.path.join(tempdir, "resnet18.onnx")
             slim(FILENAME, output_name, input_shapes=["input:1,3,224,224"], dtype="fp16")
             summary = summarize_model(output_name)
             print_model_info_as_table(request.node.name, summary)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -302,6 +302,7 @@ def list(github, force_reload=False, skip_validation=False):
             specified by the ``github`` argument properly belongs to the repo owner. This will make
             requests to the GitHub API; you can specify a non-default GitHub token by setting the
             ``GITHUB_TOKEN`` environment variable. Default is ``False``.
+
     Returns:
         list: The available callables entrypoint
 
@@ -336,6 +337,7 @@ def help(github, model, force_reload=False, skip_validation=False):
             specified by the ``github`` argument properly belongs to the repo owner. This will make
             requests to the GitHub API; you can specify a non-default GitHub token by setting the
             ``GITHUB_TOKEN`` environment variable. Default is ``False``.
+
     Example:
         >>> print(torch.hub.help('pytorch/vision', 'resnet18', force_reload=True))
     """


### PR DESCRIPTION
When a Pad op has multiple consumers, the fusion process will remove the Pad op without notifying the other consumers, which cause the other consumers to have inexistent input.
To avoid this issue, need to check the consumers of the Pad op before removing it.

Referer to: https://github.com/tsingmicro-toolchain/OnnxSlim/pull/29