### PR TITLE
Fix fusion gemm bug

### DIFF
--- a/onnxslim/core/pattern/fusion/gemm.py
+++ b/onnxslim/core/pattern/fusion/gemm.py
@@ -36,7 +36,7 @@ class MatMulAddPatternMatcher(PatternMatcher):
             matmul_node.inputs[0] if isinstance(matmul_node.inputs[1], gs.Constant) else matmul_node.inputs[1]
         )
         users = get_node_users(matmul_node)
-        if len(users) == 1 and matmul_bias_variable:
+        if len(users) == 1 and matmul_bias_variable and len(matmul_bias_variable.shape) == 2:        
             if (
                 input_variable.shape
                 and len(input_variable.shape) > 2

--- a/onnxslim/core/pattern/fusion/gemm.py
+++ b/onnxslim/core/pattern/fusion/gemm.py
@@ -36,7 +36,7 @@ class MatMulAddPatternMatcher(PatternMatcher):
             matmul_node.inputs[0] if isinstance(matmul_node.inputs[1], gs.Constant) else matmul_node.inputs[1]
         )
         users = get_node_users(matmul_node)
-        if len(users) == 1 and matmul_bias_variable and len(matmul_bias_variable.shape) == 2:        
+        if len(users) == 1 and matmul_bias_variable and len(matmul_bias_variable.shape) == 2:
             if (
                 input_variable.shape
                 and len(input_variable.shape) > 2

--- a/onnxslim/core/pattern/fusion/gemm.py
+++ b/onnxslim/core/pattern/fusion/gemm.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 import onnxslim.third_party.onnx_graphsurgeon as gs
 from onnxslim.core.optimization.dead_node_elimination import get_constant_variable
 from onnxslim.core.pattern import Pattern, PatternMatcher, get_node_users


### PR DESCRIPTION
Error message:
```
$ onnxslim sudoku_rwkv_20241120.onnx
Onnx Runtime version 1.20 has no specified compatible ONNX version.
Traceback (most recent call last):
  File "/Users/molly/miniconda3/bin/onnxslim", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/Users/molly/miniconda3/lib/python3.12/site-packages/onnxslim/cli/_main.py", line 147, in main
    slim(
  File "/Users/molly/miniconda3/lib/python3.12/site-packages/onnxslim/cli/_main.py", line 89, in slim
    model = optimize(model, skip_fusion_patterns)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/molly/miniconda3/lib/python3.12/site-packages/onnxslim/core/__init__.py", line 154, in optimize
    model = optimize_model(graph, skip_fusion_patterns)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/molly/miniconda3/lib/python3.12/site-packages/onnxslim/core/optimization/__init__.py", line 23, in optimize_model
    fusion_pairs = find_matches(graph, fusion_patterns)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/molly/miniconda3/lib/python3.12/site-packages/onnxslim/core/optimization/__init__.py", line 67, in find_matches
    match_case = pattern_matcher.rewrite(opset=graph.opset)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/molly/miniconda3/lib/python3.12/site-packages/onnxslim/core/pattern/fusion/gemm.py", line 45, in rewrite
    values=np.array([-1, matmul_bias_variable.values.shape[0]], dtype=np.int64),
           ^^
NameError: name 'np' is not defined
```