### PR TITLE
feat: add bfloat16 and fp8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Create coverage config
         run: |
           echo "[run]" > .coveragerc
-          echo "omit = onnxslim/third_party/*, onnxslim/misc/*, config.py, config-3.py" >> .coveragerc
+          echo "omit = onnxslim/third_party/*, onnxslim/misc/*, config.py, config-3.py, onnxslim/tests/test_benchmark.py, onnxslim/tests/conftest.py" >> .coveragerc
 
       # - name: yolo test
       #   if: matrix.python-version <= '3.11'

--- a/onnxslim/third_party/onnx_graphsurgeon/exporters/onnx_exporter.py
+++ b/onnxslim/third_party/onnx_graphsurgeon/exporters/onnx_exporter.py
@@ -84,52 +84,67 @@ def update_import_domains(graph):
     return graph.import_domains
 
 
-# Converts a fp32 gs.Constant to a bf16 onnx.TensorProto
-def tensor_to_onnx_bf16(tensor: Constant):
-    """Converts an fp32 gs.Constant tensor to a bf16 onnx.TensorProto."""
+class NumpyArrayConverter(object):
+    def __init__(self, container, scalar_converter):
+        self.func = np.vectorize(scalar_converter, otypes=[container])
 
-    def np_float32_to_bf16_as_uint16(arr):
-        new_arr = np.empty(arr.size, dtype=np.uint16)
-        flatten = arr.flatten()
-        for i in range(arr.size):
-            new_arr[i] = onnx.helper.float32_to_bfloat16(flatten[i])
-        return new_arr.reshape(arr.shape)
+    def __call__(self, arr):
+        return self.func(arr)
 
-    arr_bf16_as_uint16 = np_float32_to_bf16_as_uint16(tensor.values)
 
-    onnx_tensor = onnx.TensorProto()
-    onnx_tensor.data_type = onnx.TensorProto.BFLOAT16
-    onnx_tensor.dims.extend(arr_bf16_as_uint16.shape)
-    onnx_tensor.raw_data = arr_bf16_as_uint16.tobytes()
+_NUMPY_ARRAY_CONVERTERS = {
+    onnx.TensorProto.BFLOAT16: NumpyArrayConverter(
+        np.uint16, onnx.helper.float32_to_bfloat16
+    ),
+    # FP8 in TensorRT supports negative zeros, no infinities
+    # See https://onnx.ai/onnx/technical/float8.html#papers
+    onnx.TensorProto.FLOAT8E4M3FN: NumpyArrayConverter(
+        np.uint8, lambda x: onnx.helper.float32_to_float8e4m3(x, fn=True, uz=False)
+    ),
+}
 
-    return onnx_tensor
+def constant_to_onnx_tensor(tensor: Constant) -> onnx.TensorProto:
+    source_dtype = dtype_to_onnx(tensor.dtype)
+    target_dtype = dtype_to_onnx(tensor.export_dtype)
+
+    if source_dtype != target_dtype:
+        source_dtype_str = onnx.helper.tensor_dtype_to_string(source_dtype)
+        target_dtype_str = onnx.helper.tensor_dtype_to_string(target_dtype)
+        assert source_dtype == onnx.TensorProto.FLOAT, (
+            f"Cannot convert onnx dtype {source_dtype_str} to {target_dtype_str}. "
+            "Source dtype must be float32 to convert to numpy unsupported dtypes."
+        )
+        assert target_dtype in _NUMPY_ARRAY_CONVERTERS.keys(), (
+            f"Cannot convert onnx dtype {source_dtype_str} to {target_dtype_str}. "
+            f"Only float32 to {_NUMPY_ARRAY_CONVERTERS.keys()} is supported."
+        )
+        arr = _NUMPY_ARRAY_CONVERTERS[target_dtype](tensor.values)
+        tensor_raw_bytes = arr.tobytes()
+    else:
+        tensor_raw_bytes = tensor.values.tobytes()
+
+    return onnx.helper.make_tensor(
+        name=tensor.name,
+        data_type=target_dtype,
+        dims=tensor.shape,
+        vals=tensor_raw_bytes,
+        raw=True,
+    )
 
 
 class OnnxExporter(BaseExporter):
     @staticmethod
     def export_tensor_proto(tensor: Constant) -> onnx.TensorProto:
         # Do *not* load LazyValues into an intermediate numpy array - instead, use
-        """Converts a gs.Constant tensor to an onnx.TensorProto with type and data location handling."""
         # the original onnx.TensorProto directly.
         if isinstance(tensor._values, LazyValues):
             onnx_tensor = tensor._values.tensor
+            onnx_tensor.name = tensor.name
         else:
-            if dtype_to_onnx(tensor.dtype) != dtype_to_onnx(tensor.export_dtype):
-                assert tensor.dtype == np.float32, (
-                    f"Cannot convert onnx dtype {dtype_to_onnx(tensor.dtype)} to {dtype_to_onnx(tensor.export_dtype)}."
-                    "Only float32 to bfloat16 is supported"
-                )
-                assert tensor.export_dtype == onnx.TensorProto.BFLOAT16, (
-                    f"Cannot convert onnx dtype {dtype_to_onnx(tensor.dtype)} to {dtype_to_onnx(tensor.export_dtype)}."
-                    "Only float32 to bfloat16 is supported"
-                )
-                onnx_tensor = tensor_to_onnx_bf16(tensor)
-            else:
-                onnx_tensor = onnx.numpy_helper.from_array(tensor.values)
+            onnx_tensor = constant_to_onnx_tensor(tensor)
 
             if tensor.data_location is not None:
                 onnx_tensor.data_location = tensor.data_location
-        onnx_tensor.name = tensor.name
         return onnx_tensor
 
     @staticmethod

--- a/onnxslim/third_party/onnx_graphsurgeon/exporters/onnx_exporter.py
+++ b/onnxslim/third_party/onnx_graphsurgeon/exporters/onnx_exporter.py
@@ -84,7 +84,7 @@ def update_import_domains(graph):
     return graph.import_domains
 
 
-class NumpyArrayConverter(object):
+class NumpyArrayConverter:
     def __init__(self, container, scalar_converter):
         self.func = np.vectorize(scalar_converter, otypes=[container])
 
@@ -93,15 +93,14 @@ class NumpyArrayConverter(object):
 
 
 _NUMPY_ARRAY_CONVERTERS = {
-    onnx.TensorProto.BFLOAT16: NumpyArrayConverter(
-        np.uint16, onnx.helper.float32_to_bfloat16
-    ),
+    onnx.TensorProto.BFLOAT16: NumpyArrayConverter(np.uint16, onnx.helper.float32_to_bfloat16),
     # FP8 in TensorRT supports negative zeros, no infinities
     # See https://onnx.ai/onnx/technical/float8.html#papers
     onnx.TensorProto.FLOAT8E4M3FN: NumpyArrayConverter(
         np.uint8, lambda x: onnx.helper.float32_to_float8e4m3(x, fn=True, uz=False)
     ),
 }
+
 
 def constant_to_onnx_tensor(tensor: Constant) -> onnx.TensorProto:
     source_dtype = dtype_to_onnx(tensor.dtype)

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -102,7 +102,7 @@ def onnx_dtype_to_numpy(onnx_dtype: int) -> np.dtype:
 
     if onnx_dtype in onnx.helper.get_all_tensor_dtypes():
         return np.dtype(helper.tensor_dtype_to_np_dtype(onnx_dtype))
-    
+
     return "UNDEFINED"
 
 

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -571,12 +571,10 @@ def get_numpy_type(onnx_type):
 
     # TENSOR_TYPE_TO_NP_TYPE maps types unsupported by NumPy to random other types.
     # This obviously breaks things, so we need to treat this as a special case.
-    if (
-        onnx_type not in numpy_unsupported_types
-        and onnx_type in onnx.helper.get_all_tensor_dtypes()
-    ):
+    if onnx_type not in numpy_unsupported_types and onnx_type in onnx.helper.get_all_tensor_dtypes():
         return onnx.helper.tensor_dtype_to_np_dtype(onnx_type)
     return None
+
 
 def get_itemsize(dtype):
     np_dtype = get_numpy_type(dtype)
@@ -593,7 +591,7 @@ def get_itemsize(dtype):
         onnx.TensorProto.FLOAT8E5M2FNUZ,
     ]:
         return 1
-    
+
     print(dtype)
     raise
 

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -17,8 +17,8 @@ from onnxslim.third_party.onnx_graphsurgeon.logger.logger import G_LOGGER
 logger = logging.getLogger("onnxslim")
 
 import ml_dtypes
-from onnx import TensorProto
 from onnx.mapping import TensorDtypeMap
+
 TENSOR_TYPE_MAP = {}
 # Base entries (always available in ONNX)
 base_types = {
@@ -27,13 +27,13 @@ base_types = {
 
 # Optional / newer entries
 optional_types = {
-    "FLOAT8E4M3FN":    (ml_dtypes.float8_e4m3fn, "UINT8"),
-    "FLOAT8E4M3FNUZ":  (ml_dtypes.float8_e4m3fnuz, "UINT8"),
-    "FLOAT8E5M2":      (ml_dtypes.float8_e5m2, "UINT8"),
-    "FLOAT8E5M2FNUZ":  (ml_dtypes.float8_e5m2fnuz, "UINT8"),
-    "UINT4":           (ml_dtypes.uint4, "INT32"),
-    "INT4":            (ml_dtypes.int4, "INT32"),
-    "FLOAT4E2M1":      (ml_dtypes.float4_e2m1fn, "UINT8"),
+    "FLOAT8E4M3FN": (ml_dtypes.float8_e4m3fn, "UINT8"),
+    "FLOAT8E4M3FNUZ": (ml_dtypes.float8_e4m3fnuz, "UINT8"),
+    "FLOAT8E5M2": (ml_dtypes.float8_e5m2, "UINT8"),
+    "FLOAT8E5M2FNUZ": (ml_dtypes.float8_e5m2fnuz, "UINT8"),
+    "UINT4": (ml_dtypes.uint4, "INT32"),
+    "INT4": (ml_dtypes.int4, "INT32"),
+    "FLOAT4E2M1": (ml_dtypes.float4_e2m1fn, "UINT8"),
 }
 
 for name, (np_dtype, storage) in base_types.items():
@@ -46,6 +46,7 @@ for name, (np_dtype, storage) in optional_types.items():
         TENSOR_TYPE_MAP[int(getattr(onnx.TensorProto, name))] = TensorDtypeMap(
             np.dtype(np_dtype), int(getattr(onnx.TensorProto, storage)), f"TensorProto.{name}"
         )
+
 
 def init_logging(verbose=False):
     """Configure the logging settings for the application based on the verbosity level."""
@@ -97,6 +98,7 @@ def format_bytes(size: Union[int, Tuple[int, ...]]) -> str:
         return formatted_sizes[0]
     else:
         return f"{formatted_sizes[0]} ({formatted_sizes[1]})"
+
 
 def onnx_dtype_to_numpy(onnx_dtype: int) -> np.dtype:
     """Maps an ONNX dtype to its corresponding NumPy dtype."""
@@ -572,6 +574,7 @@ data_type_sizes = {
     onnx.TensorProto.INT16: 2,
     onnx.TensorProto.BOOL: 1,
 }
+
 
 def get_itemsize(dtype):
     if dtype in data_type_sizes:

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -74,6 +74,7 @@ def onnx_dtype_to_numpy(onnx_dtype: int) -> np.dtype:
     import ml_dtypes
     from onnx import TensorProto
     from onnx.mapping import TensorDtypeMap
+
     TENSOR_TYPE_MAP = {
         int(TensorProto.BFLOAT16): TensorDtypeMap(
             np.dtype(ml_dtypes.bfloat16), int(TensorProto.UINT16), "TensorProto.BFLOAT16"
@@ -91,12 +92,8 @@ def onnx_dtype_to_numpy(onnx_dtype: int) -> np.dtype:
         int(TensorProto.FLOAT8E5M2FNUZ): TensorDtypeMap(
             np.dtype(ml_dtypes.float8_e5m2fnuz), int(TensorProto.UINT8), "TensorProto.FLOAT8E5M2FNUZ"
         ),
-        int(TensorProto.UINT4): TensorDtypeMap(
-            np.dtype(ml_dtypes.uint4), int(TensorProto.INT32), "TensorProto.UINT4"
-        ),
-        int(TensorProto.INT4): TensorDtypeMap(
-            np.dtype(ml_dtypes.int4), int(TensorProto.INT32), "TensorProto.INT4"
-        ),
+        int(TensorProto.UINT4): TensorDtypeMap(np.dtype(ml_dtypes.uint4), int(TensorProto.INT32), "TensorProto.UINT4"),
+        int(TensorProto.INT4): TensorDtypeMap(np.dtype(ml_dtypes.int4), int(TensorProto.INT32), "TensorProto.INT4"),
         int(TensorProto.FLOAT4E2M1): TensorDtypeMap(
             np.dtype(ml_dtypes.float4_e2m1fn), int(TensorProto.UINT8), "TensorProto.FLOAT4E2M1"
         ),

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -22,14 +22,14 @@ from onnx.mapping import TensorDtypeMap
 TENSOR_TYPE_MAP = {}
 
 candidates = [
-    ("BFLOAT16",    "bfloat16",       "UINT16"),
-    ("FLOAT8E4M3FN",    "float8_e4m3fn",    "UINT8"),
-    ("FLOAT8E4M3FNUZ",  "float8_e4m3fnuz",  "UINT8"),
-    ("FLOAT8E5M2",      "float8_e5m2",      "UINT8"),
-    ("FLOAT8E5M2FNUZ",  "float8_e5m2fnuz",  "UINT8"),
-    ("UINT4",           "uint4",            "INT32"),
-    ("INT4",            "int4",             "INT32"),
-    ("FLOAT4E2M1",      "float4_e2m1fn",    "UINT8"),
+    ("BFLOAT16", "bfloat16", "UINT16"),
+    ("FLOAT8E4M3FN", "float8_e4m3fn", "UINT8"),
+    ("FLOAT8E4M3FNUZ", "float8_e4m3fnuz", "UINT8"),
+    ("FLOAT8E5M2", "float8_e5m2", "UINT8"),
+    ("FLOAT8E5M2FNUZ", "float8_e5m2fnuz", "UINT8"),
+    ("UINT4", "uint4", "INT32"),
+    ("INT4", "int4", "INT32"),
+    ("FLOAT4E2M1", "float4_e2m1fn", "UINT8"),
 ]
 
 for onnx_name, ml_name, storage_name in candidates:
@@ -37,7 +37,7 @@ for onnx_name, ml_name, storage_name in candidates:
         TENSOR_TYPE_MAP[int(getattr(onnx.TensorProto, onnx_name))] = TensorDtypeMap(
             np.dtype(getattr(ml_dtypes, ml_name)),
             int(getattr(onnx.TensorProto, storage_name)),
-            f"TensorProto.{onnx_name}"
+            f"TensorProto.{onnx_name}",
         )
 
 

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -100,8 +100,10 @@ def onnx_dtype_to_numpy(onnx_dtype: int) -> np.dtype:
     if tensor_dtype:
         return tensor_dtype.np_dtype
 
-    # Native numpy dtypes.
-    return np.dtype(helper.tensor_dtype_to_np_dtype(onnx_dtype))
+    if onnx_dtype in onnx.helper.get_all_tensor_dtypes():
+        return np.dtype(helper.tensor_dtype_to_np_dtype(onnx_dtype))
+    
+    return "UNDEFINED"
 
 
 def gen_onnxruntime_input_data(

--- a/onnxslim/utils.py
+++ b/onnxslim/utils.py
@@ -20,31 +20,24 @@ import ml_dtypes
 from onnx.mapping import TensorDtypeMap
 
 TENSOR_TYPE_MAP = {}
-# Base entries (always available in ONNX)
-base_types = {
-    "BFLOAT16": (ml_dtypes.bfloat16, "UINT16"),
-}
 
-# Optional / newer entries
-optional_types = {
-    "FLOAT8E4M3FN": (ml_dtypes.float8_e4m3fn, "UINT8"),
-    "FLOAT8E4M3FNUZ": (ml_dtypes.float8_e4m3fnuz, "UINT8"),
-    "FLOAT8E5M2": (ml_dtypes.float8_e5m2, "UINT8"),
-    "FLOAT8E5M2FNUZ": (ml_dtypes.float8_e5m2fnuz, "UINT8"),
-    "UINT4": (ml_dtypes.uint4, "INT32"),
-    "INT4": (ml_dtypes.int4, "INT32"),
-    "FLOAT4E2M1": (ml_dtypes.float4_e2m1fn, "UINT8"),
-}
+candidates = [
+    ("BFLOAT16",    "bfloat16",       "UINT16"),
+    ("FLOAT8E4M3FN",    "float8_e4m3fn",    "UINT8"),
+    ("FLOAT8E4M3FNUZ",  "float8_e4m3fnuz",  "UINT8"),
+    ("FLOAT8E5M2",      "float8_e5m2",      "UINT8"),
+    ("FLOAT8E5M2FNUZ",  "float8_e5m2fnuz",  "UINT8"),
+    ("UINT4",           "uint4",            "INT32"),
+    ("INT4",            "int4",             "INT32"),
+    ("FLOAT4E2M1",      "float4_e2m1fn",    "UINT8"),
+]
 
-for name, (np_dtype, storage) in base_types.items():
-    TENSOR_TYPE_MAP[int(getattr(onnx.TensorProto, name))] = TensorDtypeMap(
-        np.dtype(np_dtype), int(getattr(onnx.TensorProto, storage)), f"TensorProto.{name}"
-    )
-
-for name, (np_dtype, storage) in optional_types.items():
-    if hasattr(onnx.TensorProto, name):
-        TENSOR_TYPE_MAP[int(getattr(onnx.TensorProto, name))] = TensorDtypeMap(
-            np.dtype(np_dtype), int(getattr(onnx.TensorProto, storage)), f"TensorProto.{name}"
+for onnx_name, ml_name, storage_name in candidates:
+    if hasattr(onnx.TensorProto, onnx_name) and hasattr(ml_dtypes, ml_name):
+        TENSOR_TYPE_MAP[int(getattr(onnx.TensorProto, onnx_name))] = TensorDtypeMap(
+            np.dtype(getattr(ml_dtypes, ml_name)),
+            int(getattr(onnx.TensorProto, storage_name)),
+            f"TensorProto.{onnx_name}"
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
     license="MIT",
-    install_requires=["onnx", "sympy>=1.13.3", "packaging", "colorama"],
+    install_requires=["onnx", "sympy>=1.13.3", "packaging", "colorama", "ml_dtypes"],
     packages=find_packages(exclude=("tests", "tests.*")),
     entry_points={"console_scripts": ["onnxslim=onnxslim.cli:main"]},
     zip_safe=True,

--- a/tests/test_onnxslim.py
+++ b/tests/test_onnxslim.py
@@ -130,6 +130,52 @@ class TestFunctional:
             self.run_basic_test(FILENAME, FILENAME, **kwargs)
 
 
+    def test_unsupported_dtypes(self, request):
+        import onnxslim.third_party.onnx_graphsurgeon as gs
+        import numpy as np
+        import onnx
+
+
+        def generate(dtype, out_path):
+            X = gs.Variable(name="X", dtype=dtype, shape=(1, 3, 224, 224))
+            W = gs.Constant(
+                name="W",
+                values=np.ones(shape=(5, 3, 3, 3), dtype=np.float32) * 0.5,
+                export_dtype=dtype,
+            )
+            Y = gs.Variable(name="Y", dtype=dtype, shape=(1, 5, 222, 222))
+            node = gs.Node(op="Conv", inputs=[X, W], outputs=[Y])
+            graph = gs.Graph(nodes=[node], inputs=[X], outputs=[Y])
+            onnx.save(gs.export_onnx(graph), out_path)
+
+            # --- Assertions ---
+            loaded = onnx.load(out_path)
+
+            # Check input dtype
+            input_dtype = loaded.graph.input[0].type.tensor_type.elem_type
+            assert (
+                input_dtype == dtype
+            ), f"Expected input dtype {dtype}, got {input_dtype}"
+
+            # Check output dtype
+            output_dtype = loaded.graph.output[0].type.tensor_type.elem_type
+            assert (
+                output_dtype == dtype
+            ), f"Expected output dtype {dtype}, got {output_dtype}"
+
+            # Check constant dtype
+            for init in loaded.graph.initializer:
+                if init.name == "W":
+                    assert (
+                        init.data_type == dtype
+                    ), f"Expected W dtype {dtype}, got {init.data_type}"
+
+
+
+        generate(onnx.TensorProto.BFLOAT16, "test_conv_bf16.onnx")
+        generate(onnx.TensorProto.FLOAT8E4M3FN, "test_conv_float8e4m3fn.onnx")
+
+
 if __name__ == "__main__":
     import sys
 

--- a/tests/test_onnxslim.py
+++ b/tests/test_onnxslim.py
@@ -129,12 +129,11 @@ class TestFunctional:
             kwargs["api"] = {"inspect": True}
             self.run_basic_test(FILENAME, FILENAME, **kwargs)
 
-
     def test_unsupported_dtypes(self, request):
-        import onnxslim.third_party.onnx_graphsurgeon as gs
         import numpy as np
         import onnx
 
+        import onnxslim.third_party.onnx_graphsurgeon as gs
 
         def generate(dtype, out_path):
             X = gs.Variable(name="X", dtype=dtype, shape=(1, 3, 224, 224))
@@ -153,24 +152,16 @@ class TestFunctional:
 
             # Check input dtype
             input_dtype = loaded.graph.input[0].type.tensor_type.elem_type
-            assert (
-                input_dtype == dtype
-            ), f"Expected input dtype {dtype}, got {input_dtype}"
+            assert input_dtype == dtype, f"Expected input dtype {dtype}, got {input_dtype}"
 
             # Check output dtype
             output_dtype = loaded.graph.output[0].type.tensor_type.elem_type
-            assert (
-                output_dtype == dtype
-            ), f"Expected output dtype {dtype}, got {output_dtype}"
+            assert output_dtype == dtype, f"Expected output dtype {dtype}, got {output_dtype}"
 
             # Check constant dtype
             for init in loaded.graph.initializer:
                 if init.name == "W":
-                    assert (
-                        init.data_type == dtype
-                    ), f"Expected W dtype {dtype}, got {init.data_type}"
-
-
+                    assert init.data_type == dtype, f"Expected W dtype {dtype}, got {init.data_type}"
 
         generate(onnx.TensorProto.BFLOAT16, "test_conv_bf16.onnx")
         generate(onnx.TensorProto.FLOAT8E4M3FN, "test_conv_float8e4m3fn.onnx")


### PR DESCRIPTION
Closes #27 
Closes #169 

This pr refers to https://github.com/NVIDIA/TensorRT, and add supports for different numpy unsupported dtypes.