### PR TITLE
Update dependency installation step in nightly test

### DIFF
--- a/.github/workflows/nightly-test.yml
+++ b/.github/workflows/nightly-test.yml
@@ -81,7 +81,7 @@ jobs:
       - name: install dependency
         run: |
           python -m pip install --upgrade pip wheel setuptools
-          pip install .
+          uv sync --dev
           pip install pytest onnx onnxruntime parameterized transformers "optimum[onnxruntime]"
 
       - name: optimum test


### PR DESCRIPTION
Replaced pip install with uv sync command before installing other dependencies.