### PR TITLE
fix: duplicated tensor creation

### DIFF
--- a/onnxslim/core/pattern/fusion/concat_reshape.py
+++ b/onnxslim/core/pattern/fusion/concat_reshape.py
@@ -36,9 +36,11 @@ class ConcatReshapeMatcher(PatternMatcher):
     def rewrite(self, opset=11):
         match_case = {}
         concat_node = self.concat_0
+        reshape_node = self.reshape_0
         index = next(idx for idx, i in enumerate(concat_node.inputs) if isinstance(i, gs.Variable))
+        output_name = reshape_node.outputs[0].name
         constant = gs.Constant(
-            concat_node.inputs[index].name + "_fixed",
+            output_name + "_fixed",
             values=np.array([-1], dtype=np.int64),
         )
         concat_node.inputs.pop(index)

--- a/onnxslim/core/pattern/fusion/convadd.py
+++ b/onnxslim/core/pattern/fusion/convadd.py
@@ -44,12 +44,8 @@ class ConvAddMatcher(PatternMatcher):
             inputs = []
             inputs.append(next(iter(conv_node.inputs)))
             inputs.append(conv_weight)
-            weight_name = list(conv_node.inputs)[1].name
-            if weight_name.endswith("weight"):
-                bias_name = f"{weight_name[:-6]}bias"
-            else:
-                bias_name = f"{weight_name}_bias"
-            inputs.append(gs.Constant(bias_name, values=conv_bias))
+            output_name = add_node.outputs[0].name
+            inputs.append(gs.Constant(output_name + "_bias", values=conv_bias))
             outputs = list(add_node.outputs)
 
             conv_node.outputs.clear()

--- a/onnxslim/core/pattern/fusion/convbn.py
+++ b/onnxslim/core/pattern/fusion/convbn.py
@@ -52,15 +52,11 @@ class ConvBatchNormMatcher(PatternMatcher):
 
             inputs = []
             inputs.append(next(iter(conv_transpose_node.inputs)))
-            weight_name = list(conv_transpose_node.inputs)[1].name
-            if weight_name.endswith("weight"):
-                bias_name = f"{weight_name[:-6]}bias"
-            else:
-                bias_name = f"{weight_name}_bias"
+            output_name = bn_node.outputs[0].name
             inputs.extend(
                 (
-                    gs.Constant(weight_name + "_weight", values=conv_w),
-                    gs.Constant(bias_name, values=conv_b),
+                    gs.Constant(output_name + "_weight", values=conv_w),
+                    gs.Constant(output_name + "_bias", values=conv_b),
                 )
             )
             outputs = list(bn_node.outputs)

--- a/onnxslim/core/pattern/fusion/convmul.py
+++ b/onnxslim/core/pattern/fusion/convmul.py
@@ -38,14 +38,13 @@ class ConvMulMatcher(PatternMatcher):
                 inputs = []
                 inputs.append(next(iter(conv_node.inputs)))
 
-                weight_name = list(conv_node.inputs)[1].name
-                inputs.append(gs.Constant(weight_name, values=new_weight))
+                output_name = mul_node.outputs[0].name
+                inputs.append(gs.Constant(output_name + "_weight", values=new_weight))
 
                 if len(conv_node.inputs) == 3:
                     conv_bias = conv_node.inputs[2].values
                     new_bias = conv_bias * mul_constant.squeeze()
-                    bias_name = list(conv_node.inputs)[2].name
-                    inputs.append(gs.Constant(bias_name, values=new_bias))
+                    inputs.append(gs.Constant(output_name + "_bias", values=new_bias))
 
                 outputs = list(mul_node.outputs)
 

--- a/onnxslim/core/pattern/fusion/gemm.py
+++ b/onnxslim/core/pattern/fusion/gemm.py
@@ -76,7 +76,7 @@ class MatMulAddPatternMatcher(PatternMatcher):
                 output_variable.outputs.remove(add_node)
 
                 matmul_bias_transpose_constant = gs.Constant(
-                    matmul_bias_variable.name, values=matmul_bias_variable.values.T
+                    f"{matmul_node.name}_weight", values=matmul_bias_variable.values.T
                 )
 
                 inputs = []
@@ -143,7 +143,7 @@ class MatMulAddPatternMatcher(PatternMatcher):
                 output_variable.outputs.remove(add_node)
 
                 matmul_bias_transpose_constant = gs.Constant(
-                    matmul_bias_variable.name, values=matmul_bias_variable.values.T
+                    f"{matmul_node.name}_weight", values=matmul_bias_variable.values.T
                 )
 
                 inputs = []
@@ -235,14 +235,15 @@ class GemmMulPatternMatcher(PatternMatcher):
                     gemm_weight_fused = gemm_weight * mul_weight[:, None]
                 else:
                     gemm_weight_fused = gemm_weight * mul_weight
-                gemm_weight_fused_constant = gs.Constant(gemm_weight_constant.name + "_fused", values=gemm_weight_fused)
+                output_name = reshape_node.outputs[0].name
+                gemm_weight_fused_constant = gs.Constant(output_name + "_weight_fused", values=gemm_weight_fused)
                 gemm_node.inputs[1] = gemm_weight_fused_constant
 
                 if gemm_bias_constant:
                     gemm_bias = gemm_bias_constant.values
                     mul_bias = mul_bias_variable.values
                     gemm_bias_fused = gemm_bias * mul_bias
-                    gemm_bias_fused_constant = gs.Constant(gemm_bias_constant.name + "_fused", values=gemm_bias_fused)
+                    gemm_bias_fused_constant = gs.Constant(output_name + "_bias_fused", values=gemm_bias_fused)
                     gemm_node.inputs[2] = gemm_bias_fused_constant
 
                 mul_node.replace_all_uses_with(reshape_node)
@@ -312,7 +313,8 @@ class GemmAddPatternMatcher(PatternMatcher):
                     and add_bias.ndim <= 2
                 ):
                     gemm_bias_fused = gemm_bias + add_bias
-                    gemm_bias_fused_constant = gs.Constant(gemm_bias_constant.name + "_fused", values=gemm_bias_fused)
+                    output_name = reshape_node.outputs[0].name
+                    gemm_bias_fused_constant = gs.Constant(output_name + "_bias_fused", values=gemm_bias_fused)
                     gemm_node.inputs[2] = gemm_bias_fused_constant
                 else:
                     return match_case

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ testpaths = [
     "tests/test_nvidia.py",
     "tests/test_shape_folding.py",
     "tests/test_coverage.py",
+    "tests/test_amd.py",
 ]
 addopts = "-n auto" # enables pytest-xdist parallel workers
 

--- a/tests/test_amd.py
+++ b/tests/test_amd.py
@@ -1,0 +1,90 @@
+import os
+import tempfile
+
+import numpy as np
+import onnxruntime as ort
+import pytest
+
+import onnx
+from onnxslim import slim
+from onnxslim.utils import print_model_info_as_table, summarize_model
+
+MODELZOO_PATH = "/data/modelzoo/amd"
+
+def get_input_shapes(graph):
+    input_shapes = {}
+    for input in graph.input:
+        input_shapes[input.name] = [
+            s.dim_value for s in input.type.tensor_type.shape.dim
+        ]
+    return input_shapes
+
+
+def load_dummy_data(input_shape, data_size=5):
+    """Generate dummy input dicts."""
+    for _ in range(data_size):
+        data = {}
+        for name, shape in input_shape.items():
+            data[name] = np.random.rand(*shape).astype(np.float32)
+        yield data
+
+
+def run_slim_and_compare(original_path: str, slim_path: str, data_size=5):
+    """
+    Compare ORT inference results between original and slim models.
+    Slimming must already be done outside this function.
+    """
+    # ==== Prepare input shape ====
+    model = onnx.load(original_path)
+    input_shape = get_input_shapes(model.graph)
+
+    # fix dynamic dims → 1
+    for name, shape in input_shape.items():
+        input_shape[name] = [1 if s < 1 else s for s in shape]
+
+    data_gen = load_dummy_data(input_shape, data_size=data_size)
+
+    # ==== ORT sessions ====
+    opts = ort.SessionOptions()
+    opts.graph_optimization_level = ort.GraphOptimizationLevel.ORT_ENABLE_EXTENDED
+    opts.log_severity_level = 3
+    EP = ["CPUExecutionProvider"]
+
+    sess_orig = ort.InferenceSession(original_path, sess_options=opts, providers=EP)
+    sess_slim = ort.InferenceSession(slim_path, sess_options=opts, providers=EP)
+
+    # ==== Compare outputs ====
+    for inp in data_gen:
+        out1 = sess_orig.run([], inp)
+        out2 = sess_slim.run([], inp)
+
+        for a, b in zip(out1, out2):
+            if not np.array_equal(a, b):
+                return False
+    return True
+
+class TestModelZoo:
+    def test_EliminationSlice(self, request):
+        name = request.node.originalname[len("test_") :]
+        filename = f"{MODELZOO_PATH}/{name}.onnx"
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            slim_path = os.path.join(tempdir, f"{name}_slim.onnx")
+            slim(filename, slim_path)
+            ok = run_slim_and_compare(filename, slim_path)
+            assert ok, f"onnxslim output mismatch for model {name}!"
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(
+        pytest.main(
+            [
+                "-p",
+                "no:warnings",
+                "-sv",
+                "tests/test_amd.py",
+            ]
+        )
+    )


### PR DESCRIPTION
Closes #277 

If a variable has many users, onnxslim may create tensor with same name but different value, the last created one will be used, this will give a wrong output. we can consider using node.name as an alternative, but that's optional, so use output name can be a good choice.