### PR TITLE
fix: guard against missing optional axes input in ReduceSum fusion

### DIFF
--- a/onnxslim/core/pattern/fusion/reduce.py
+++ b/onnxslim/core/pattern/fusion/reduce.py
@@ -34,6 +34,8 @@ class ReducePatternMatcher(PatternMatcher):
                 reduce_node_axes = reduce_node.attrs.get("axes", None)
                 reduce_node_keepdims = reduce_node.attrs.get("keepdims", 1)
                 unsqueeze_node_axes = unsqueeze_node.attrs.get("axes", None)
+            elif len(reduce_node.inputs) < 2:
+                return match_case
             else:
                 reduce_node_axes_ = reduce_node.inputs[1]
                 reduce_node_keepdims = reduce_node.attrs.get("keepdims", 1)

--- a/tests/test_fusion_patterns.py
+++ b/tests/test_fusion_patterns.py
@@ -532,6 +532,27 @@ class TestFusionPatterns(unittest.TestCase):
         self.assertTrue(hasattr(matcher, "match"))
         self.assertTrue(hasattr(matcher, "rewrite"))
 
+    def test_reduce_pattern_no_axes_input(self):
+        # Test the Reduce pattern matcher without axes input
+        input_tensor = helper.make_tensor_value_info("input", TensorProto.FLOAT, [2, 3, 4])
+        output_tensor = helper.make_tensor_value_info("output", TensorProto.FLOAT, [1])
+        unsqueeze_axes = numpy_helper.from_array(np.array([0], dtype=np.int64), name="unsqueeze_axes")
+
+        reduce_node = helper.make_node("ReduceSum", ["input"], ["reduce_output"], keepdims=0)
+        unsqueeze_node = helper.make_node("Unsqueeze", ["reduce_output", "unsqueeze_axes"], ["output"])
+
+        graph = helper.make_graph(
+            [reduce_node, unsqueeze_node],
+            "reduce-no-axes-test",
+            [input_tensor],
+            [output_tensor],
+            initializer=[unsqueeze_axes],
+        )
+        model = helper.make_model(graph, producer_name="onnxslim-test")
+        model.opset_import[0].version = 13
+
+        onnxslim.slim(model)
+
     def test_gelu_pattern(self):
         # Test the Gelu pattern matcher
         matcher = GeluPatternMatcher(1)


### PR DESCRIPTION
- In ONNX opset 13+, `ReduceSum`'s `axes` was moved from an attribute to an **optional** input. A valid node may therefore have only one input (`data`), with reduction behavior controlled by the `noop_with_empty_axes` attribute.
- `ReducePatternMatcher.rewrite` unconditionally indexes `reduce_node.inputs[1]` in the opset≥13 branch, which raises `IndexError` and aborts the whole optimization pass when such a node appears in a `ReduceSum -> Unsqueeze` pattern.
- Added a guard so `ReduceSum` nodes without an explicit `axes` input are simply skipped from this fusion (returning an empty `match_case`), consistent with how the rest of the file handles non-fusable cases.
