### PR TITLE
feat: eliminate empty inputs from Concat nodes

### DIFF
--- a/onnxslim/core/optimization/dead_node_elimination.py
+++ b/onnxslim/core/optimization/dead_node_elimination.py
@@ -106,13 +106,17 @@ def dead_node_elimination(graph, is_subgraph=False):
                 node.erase()
                 logger.debug(f"removing {node.op} op: {node.name}")
         elif node.op == "Concat":
+            axis = node.attrs.get("axis", 0)
+            for input in list(node.inputs):
+                if len(node.inputs) == 1:
+                    break
+                if isinstance(input, Constant) and input.values.size == 0:
+                    node.inputs.remove(input)
+                elif isinstance(input, Variable) and is_empty_along_axis(input, axis):
+                    node.inputs.remove(input)
             if len(node.inputs) == 1:
                 node.erase()
                 logger.debug(f"removing {node.op} op: {node.name}")
-            else:
-                for input in node.inputs:
-                    if isinstance(input, Constant) and input.values.size == 0:
-                        node.inputs.remove(input)
         elif node.op == "Sub":
             if isinstance(node.inputs[1], Constant) and isinstance(node.inputs[0], Variable):
                 constant_variable = node.inputs[1]
@@ -168,6 +172,19 @@ def get_constant_variable(node, return_idx=False):
     for idx, input in enumerate(list(node.inputs)):
         if isinstance(input, Constant):
             return (idx, input) if return_idx else input
+
+
+def is_empty_along_axis(input, axis):
+    """Return True if the input has a known shape whose dimension along the concat axis is statically 0."""
+    input_shape = input.shape
+    if input_shape is None:
+        return False
+    if axis < 0:
+        axis += len(input_shape)
+    if not 0 <= axis < len(input_shape):
+        return False
+    dim = input_shape[axis]
+    return isinstance(dim, int) and dim == 0
 
 
 def is_noop_slice(node):

--- a/onnxslim/core/optimization/dead_node_elimination.py
+++ b/onnxslim/core/optimization/dead_node_elimination.py
@@ -115,8 +115,21 @@ def dead_node_elimination(graph, is_subgraph=False):
                 elif isinstance(input, Variable) and is_empty_along_axis(input, axis):
                     node.inputs.remove(input)
             if len(node.inputs) == 1:
-                node.erase()
-                logger.debug(f"removing {node.op} op: {node.name}")
+                input_is_graph_output = any(node.inputs[0] is output for output in graph.outputs)
+                output_is_graph_output = any(node.outputs[0] is output for output in graph.outputs)
+                if input_is_graph_output and not output_is_graph_output:
+                    input_var = node.inputs[0]
+                    output_var = node.outputs[0]
+                    for consumer in list(output_var.outputs):
+                        for idx, consumer_input in enumerate(consumer.inputs):
+                            if consumer_input is output_var:
+                                consumer.inputs[idx] = input_var
+                    node.inputs.clear()
+                    node.outputs.clear()
+                    logger.debug(f"removing {node.op} op: {node.name}")
+                elif not input_is_graph_output:
+                    node.erase()
+                    logger.debug(f"removing {node.op} op: {node.name}")
         elif node.op == "Sub":
             if isinstance(node.inputs[1], Constant) and isinstance(node.inputs[0], Variable):
                 constant_variable = node.inputs[1]

--- a/tests/test_dead_node_elimination.py
+++ b/tests/test_dead_node_elimination.py
@@ -306,6 +306,72 @@ class TestDeadNodeElimination:
 
         self._assert_graph_valid(graph, "Concat")
 
+    def test_concat_empty_input_elimination(self):
+        """Test Concat empty-input elimination across multiple scenarios."""
+
+        graph_input = gs.Variable(name="input", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        x = gs.Variable(name="X", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        y = gs.Variable(name="Y", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        empty_constant = gs.Constant(name="empty_constant", values=np.empty((1, 2, 0, 3, 5), dtype=np.float32))
+        empty_variable = gs.Variable(name="empty_variable", dtype=np.float32, shape=[1, 2, 0, 3, 5])
+        empty_variable_2 = gs.Variable(name="empty_variable_2", dtype=np.float32, shape=[1, 2, 0, 3, 5])
+        empty_symbolic = gs.Variable(name="empty_symbolic", dtype=np.float32, shape=[1, "N", 0, 3, 5])
+        symbolic_axis = gs.Variable(name="symbolic_axis", dtype=np.float32, shape=[1, "N", 4, 3, 5])
+        o_constant = gs.Variable(name="o_constant", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_variable = gs.Variable(name="o_variable", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_symbolic = gs.Variable(name="o_symbolic", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_multi_input = gs.Variable(name="o_multi_input", dtype=np.float32, shape=[1, 2, 8, 3, 5])
+        o_symbolic_kept = gs.Variable(name="o_symbolic_kept", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_guard = gs.Variable(name="o_guard", dtype=np.float32, shape=[1, 2, 0, 3, 5])
+
+        class RecordingConcat(gs.Node):
+            def __init__(self, **kwargs):
+                super().__init__(**kwargs)
+                self.input_counts_at_erase = []
+
+            def erase(self, input_var_idx=0, output_var_idx=0):
+                self.input_counts_at_erase.append(len(self.inputs))
+                return super().erase(input_var_idx, output_var_idx)
+
+        relu = gs.Node(op="Relu", inputs=[graph_input], outputs=[x])
+        concat_constant = gs.Node(op="Concat", inputs=[x, empty_constant], outputs=[o_constant], attrs={"axis": 2})
+        concat_variable = gs.Node(op="Concat", inputs=[x, empty_variable], outputs=[o_variable], attrs={"axis": 2})
+        concat_symbolic = gs.Node(op="Concat", inputs=[x, empty_symbolic], outputs=[o_symbolic], attrs={"axis": 2})
+        concat_multi_input = gs.Node(op="Concat", inputs=[x, y, empty_variable], outputs=[o_multi_input], attrs={"axis": 2})
+        concat_symbolic_kept = gs.Node(op="Concat", inputs=[x, symbolic_axis], outputs=[o_symbolic_kept], attrs={"axis": 1})
+        concat_guard = RecordingConcat(
+            op="Concat", inputs=[empty_variable_2, empty_variable], outputs=[o_guard], attrs={"axis": 2}
+        )
+
+        graph = gs.Graph(
+            nodes=[relu, concat_constant, concat_variable, concat_symbolic, concat_multi_input, concat_symbolic_kept, concat_guard],
+            inputs=[graph_input, y, empty_variable, empty_variable_2, empty_symbolic, symbolic_axis],
+            outputs=[o_constant, o_variable, o_symbolic, o_multi_input, o_symbolic_kept, o_guard],
+        )
+
+        dead_node_elimination(graph)
+
+        # Empty Constant / empty Variable / empty Variable with symbolic dims:
+        # the empty input is removed and the single-input Concat is erased.
+        assert not concat_constant.inputs and not concat_constant.outputs
+        assert not concat_variable.inputs and not concat_variable.outputs
+        assert not concat_symbolic.inputs and not concat_symbolic.outputs
+        # Multi-input Concat: the empty input is removed and the node is kept
+        # with the two non-empty inputs.
+        assert empty_variable not in concat_multi_input.inputs
+        assert len(concat_multi_input.inputs) == 2
+        assert concat_multi_input in graph.nodes
+        # Symbolic concat axis: emptiness is not provable, so the input is kept.
+        assert symbolic_axis in concat_symbolic_kept.inputs
+        assert len(concat_symbolic_kept.inputs) == 2
+        assert concat_symbolic_kept in graph.nodes
+        # Two empty inputs: the guard keeps exactly one input before erase,
+        # so a zero-input Concat never occurs.
+        assert concat_guard.input_counts_at_erase == [1]
+        assert not concat_guard.inputs and not concat_guard.outputs
+        graph.cleanup().toposort()
+        assert all(node.inputs for node in graph.nodes)
+
     def test_single_output_split_elimination(self, request):
         """Test that Split nodes with a single output are eliminated."""
 

--- a/tests/test_dead_node_elimination.py
+++ b/tests/test_dead_node_elimination.py
@@ -319,6 +319,8 @@ class TestDeadNodeElimination:
         symbolic_axis = gs.Variable(name="symbolic_axis", dtype=np.float32, shape=[1, "N", 4, 3, 5])
         o_constant = gs.Variable(name="o_constant", dtype=np.float32, shape=[1, 2, 4, 3, 5])
         o_variable = gs.Variable(name="o_variable", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_variable_abs = gs.Variable(name="o_variable_abs", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_variable_neg = gs.Variable(name="o_variable_neg", dtype=np.float32, shape=[1, 2, 4, 3, 5])
         o_symbolic = gs.Variable(name="o_symbolic", dtype=np.float32, shape=[1, 2, 4, 3, 5])
         o_multi_input = gs.Variable(name="o_multi_input", dtype=np.float32, shape=[1, 2, 8, 3, 5])
         o_symbolic_kept = gs.Variable(name="o_symbolic_kept", dtype=np.float32, shape=[1, "N_plus_2", 4, 3, 5])
@@ -342,11 +344,19 @@ class TestDeadNodeElimination:
         concat_guard = RecordingConcat(
             op="Concat", inputs=[empty_variable_2, empty_variable], outputs=[o_guard], attrs={"axis": 2}
         )
+        variable_abs = gs.Node(op="Abs", inputs=[o_variable], outputs=[o_variable_abs])
+        variable_neg = gs.Node(op="Neg", inputs=[o_variable], outputs=[o_variable_neg])
 
         graph = gs.Graph(
-            nodes=[relu, concat_constant, concat_variable, concat_symbolic, concat_multi_input, concat_symbolic_kept, concat_guard],
+            nodes=[
+                relu, concat_constant, concat_variable, concat_symbolic, concat_multi_input,
+                concat_symbolic_kept, concat_guard, variable_abs, variable_neg,
+            ],
             inputs=[graph_input, y, empty_variable, empty_variable_2, empty_symbolic, symbolic_axis],
-            outputs=[o_constant, o_variable, o_symbolic, o_multi_input, o_symbolic_kept, o_guard],
+            outputs=[
+                o_constant, o_variable_abs, o_variable_neg, o_symbolic,
+                o_multi_input, o_symbolic_kept, o_guard,
+            ],
         )
 
         # Match the boundary metadata populated when a real ONNX model is
@@ -358,11 +368,15 @@ class TestDeadNodeElimination:
 
         dead_node_elimination(graph)
 
-        # The first graph-output Concat is erased. Later Concats retain their
-        # output aliases because their shared input is now a graph output.
+        # The first graph-output Concat is erased. The Variable case becomes
+        # an internal single-input Concat whose consumers are reconnected to
+        # the graph output without dropping either branch.
         assert not concat_constant.inputs and not concat_constant.outputs
-        assert concat_variable.inputs == [o_constant]
-        assert concat_variable.outputs == [o_variable]
+        assert not concat_variable.inputs and not concat_variable.outputs
+        assert variable_abs.inputs == [o_constant]
+        assert variable_neg.inputs == [o_constant]
+        # A later graph-output Concat retains its output alias because its
+        # shared input is already a graph output.
         assert concat_symbolic.inputs == [o_constant]
         assert concat_symbolic.outputs == [o_symbolic]
         assert relu.outputs == [o_constant]

--- a/tests/test_dead_node_elimination.py
+++ b/tests/test_dead_node_elimination.py
@@ -321,7 +321,7 @@ class TestDeadNodeElimination:
         o_variable = gs.Variable(name="o_variable", dtype=np.float32, shape=[1, 2, 4, 3, 5])
         o_symbolic = gs.Variable(name="o_symbolic", dtype=np.float32, shape=[1, 2, 4, 3, 5])
         o_multi_input = gs.Variable(name="o_multi_input", dtype=np.float32, shape=[1, 2, 8, 3, 5])
-        o_symbolic_kept = gs.Variable(name="o_symbolic_kept", dtype=np.float32, shape=[1, 2, 4, 3, 5])
+        o_symbolic_kept = gs.Variable(name="o_symbolic_kept", dtype=np.float32, shape=[1, "N_plus_2", 4, 3, 5])
         o_guard = gs.Variable(name="o_guard", dtype=np.float32, shape=[1, 2, 0, 3, 5])
 
         class RecordingConcat(gs.Node):
@@ -349,26 +349,38 @@ class TestDeadNodeElimination:
             outputs=[o_constant, o_variable, o_symbolic, o_multi_input, o_symbolic_kept, o_guard],
         )
 
+        # Match the boundary metadata populated when a real ONNX model is
+        # imported by GraphSurgeon.
+        for input in graph.inputs:
+            input.is_input = True
+        for output in graph.outputs:
+            output.is_output = True
+
         dead_node_elimination(graph)
 
-        # Empty Constant / empty Variable / empty Variable with symbolic dims:
-        # the empty input is removed and the single-input Concat is erased.
+        # The first graph-output Concat is erased. Later Concats retain their
+        # output aliases because their shared input is now a graph output.
         assert not concat_constant.inputs and not concat_constant.outputs
-        assert not concat_variable.inputs and not concat_variable.outputs
-        assert not concat_symbolic.inputs and not concat_symbolic.outputs
+        assert concat_variable.inputs == [o_constant]
+        assert concat_variable.outputs == [o_variable]
+        assert concat_symbolic.inputs == [o_constant]
+        assert concat_symbolic.outputs == [o_symbolic]
+        assert relu.outputs == [o_constant]
         # Multi-input Concat: the empty input is removed and the node is kept
         # with the two non-empty inputs.
         assert empty_variable not in concat_multi_input.inputs
-        assert len(concat_multi_input.inputs) == 2
+        assert concat_multi_input.inputs == [o_constant, y]
         assert concat_multi_input in graph.nodes
         # Symbolic concat axis: emptiness is not provable, so the input is kept.
         assert symbolic_axis in concat_symbolic_kept.inputs
-        assert len(concat_symbolic_kept.inputs) == 2
+        assert concat_symbolic_kept.inputs == [o_constant, symbolic_axis]
         assert concat_symbolic_kept in graph.nodes
-        # Two empty inputs: the guard keeps exactly one input before erase,
-        # so a zero-input Concat never occurs.
+        # Two empty graph inputs: keep one input so a zero-input Concat is
+        # never created. Node.erase must retain the graph-input-to-output alias.
         assert concat_guard.input_counts_at_erase == [1]
-        assert not concat_guard.inputs and not concat_guard.outputs
+        assert concat_guard.inputs == [empty_variable]
+        assert concat_guard.outputs == [o_guard]
+        assert concat_guard in graph.nodes
         graph.cleanup().toposort()
         assert all(node.inputs for node in graph.nodes)
 

--- a/tests/test_modelzoo.py
+++ b/tests/test_modelzoo.py
@@ -233,7 +233,7 @@ class TestModelZoo:
 
             summary = summarize_model(os.path.join(tempdir, f"{name}_slim.onnx"), tag=request.node.name)
             assert summary.op_type_counts["Add"] == 25
-            assert summary.op_type_counts["Concat"] == 44
+            assert summary.op_type_counts["Concat"] == 43
 
     def test_tiny_vit_21m_512(self, request):
         name = request.node.originalname[len("test_") :]


### PR DESCRIPTION
Related to #327 

This change extends dead-node elimination for ONNX `Concat` nodes.

- Remove a `Variable` only when its concatenation-axis dimension is a known
  integer equal to zero.
- Retain inputs with an unknown shape, an invalid axis, or a symbolic
  concatenation-axis dimension.
- Remove empty inputs from a multi-input `Concat` while keeping the node when
  multiple valid inputs remain. It will be eliminated when only one input remains.

| Input case | Empty condition | Elimination result |
| --- | --- | --- |
| `Variable` | The concat-axis dimension is statically `0` | Remove the input |
| `Variable` with symbolic non-axis dimensions | The concat-axis dimension is statically `0` | Remove the input |
| General `Concat` node | One or more inputs meet an empty condition above | Remove empty inputs; eliminate the node if one input remains, otherwise retain it |
| `Concat` with all inputs empty | Every input meets an empty condition above | Keep one input before eliminating the node, avoiding a zero-input `Concat` |

Related to #329
It's necessary to preserve graph outputs when eliminating concat.
[case.tar.gz](https://github.com/user-attachments/files/31300353/case.tar.gz)

